### PR TITLE
Rust for VGEM

### DIFF
--- a/drivers/gpu/drm/Kconfig
+++ b/drivers/gpu/drm/Kconfig
@@ -245,6 +245,17 @@ source "drivers/gpu/drm/kmb/Kconfig"
 
 config DRM_VGEM
 	tristate "Virtual GEM provider"
+	depends on !RUST
+	depends on DRM && MMU
+	select DRM_GEM_SHMEM_HELPER
+	help
+	  Choose this option to get a virtual graphics memory manager,
+	  as used by Mesa's software renderer for enhanced performance.
+	  If M is selected the module will be called vgem.
+
+config DRM_RUSTGEM
+	tristate "Virtual GEM provider written in Rust"
+	depends on RUST
 	depends on DRM && MMU
 	select DRM_GEM_SHMEM_HELPER
 	help

--- a/drivers/gpu/drm/Makefile
+++ b/drivers/gpu/drm/Makefile
@@ -150,6 +150,7 @@ obj-$(CONFIG_DRM_SAVAGE)+= savage/
 obj-$(CONFIG_DRM_VMWGFX)+= vmwgfx/
 obj-$(CONFIG_DRM_VIA)	+=via/
 obj-$(CONFIG_DRM_VGEM)	+= vgem/
+obj-$(CONFIG_DRM_RUSTGEM) += rustgem/
 obj-$(CONFIG_DRM_VKMS)	+= vkms/
 obj-$(CONFIG_DRM_NOUVEAU) +=nouveau/
 obj-$(CONFIG_DRM_EXYNOS) +=exynos/

--- a/drivers/gpu/drm/rustgem/Makefile
+++ b/drivers/gpu/drm/rustgem/Makefile
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+obj-$(CONFIG_DRM_RUSTGEM)	+= vgem.o

--- a/drivers/gpu/drm/rustgem/fence.rs
+++ b/drivers/gpu/drm/rustgem/fence.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+
+use core::fmt::Write;
+use core::ops::Deref;
+use kernel::c_str;
+use kernel::dma_fence::*;
+use kernel::prelude::*;
+use kernel::sync::Arc;
+
+static QUEUE_NAME: &CStr = c_str!("vgem_fence");
+static QUEUE_CLASS_KEY: kernel::sync::LockClassKey = kernel::sync::LockClassKey::new();
+
+pub(crate) struct Fence {}
+
+#[vtable]
+impl FenceOps for Fence {
+    const USE_64BIT_SEQNO: bool = false;
+
+    fn get_driver_name<'a>(self: &'a FenceObject<Self>) -> &'a CStr {
+        c_str!("vgem")
+    }
+
+    fn get_timeline_name<'a>(self: &'a FenceObject<Self>) -> &'a CStr {
+        c_str!("unbound")
+    }
+
+    fn fence_value_str(self: &FenceObject<Self>, output: &mut dyn Write) {
+        let _ = output.write_fmt(format_args!("{}", self.seqno()));
+    }
+
+    fn timeline_value_str(self: &FenceObject<Self>, output: &mut dyn Write) {
+        let value = if self.is_signaled() { self.seqno() } else { 0 };
+        let _ = output.write_fmt(format_args!("{}", value));
+    }
+}
+
+pub(crate) struct VgemFence {
+    fence: Arc<UniqueFence<Fence>>,
+}
+
+impl VgemFence {
+    pub(crate) fn create() -> Result<Self> {
+        let fence_ctx = FenceContexts::new(1, QUEUE_NAME, &QUEUE_CLASS_KEY)?;
+        let fence = Arc::try_new(fence_ctx.new_fence(0, Fence {})?)?;
+
+        Ok(Self { fence })
+    }
+}
+
+impl Deref for VgemFence {
+    type Target = UniqueFence<Fence>;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.fence
+    }
+}

--- a/drivers/gpu/drm/rustgem/fence.rs
+++ b/drivers/gpu/drm/rustgem/fence.rs
@@ -2,10 +2,13 @@
 
 use core::fmt::Write;
 use core::ops::Deref;
-use kernel::c_str;
+use core::time::Duration;
 use kernel::dma_fence::*;
 use kernel::prelude::*;
 use kernel::sync::Arc;
+use kernel::time::timer::*;
+use kernel::time::*;
+use kernel::{bindings, c_str, timer_init};
 
 static QUEUE_NAME: &CStr = c_str!("vgem_fence");
 static QUEUE_CLASS_KEY: kernel::sync::LockClassKey = kernel::sync::LockClassKey::new();
@@ -36,6 +39,7 @@ impl FenceOps for Fence {
 
 pub(crate) struct VgemFence {
     fence: Arc<UniqueFence<Fence>>,
+    _timer: Box<FnTimer<Box<dyn FnMut() -> Result<Next> + Sync>>>,
 }
 
 impl VgemFence {
@@ -43,7 +47,30 @@ impl VgemFence {
         let fence_ctx = FenceContexts::new(1, QUEUE_NAME, &QUEUE_CLASS_KEY)?;
         let fence = Arc::try_new(fence_ctx.new_fence(0, Fence {})?)?;
 
-        Ok(Self { fence })
+        // SAFETY: The caller calls [`FnTimer::init_timer`] before using the timer.
+        let t = Box::try_new(unsafe {
+            FnTimer::new(Box::try_new({
+                let fence = fence.clone();
+                move || {
+                    let _ = fence.signal();
+                    Ok(Next::Done)
+                }
+            })? as Box<_>)
+        })?;
+
+        // SAFETY: As FnTimer is inside a Box, it won't be moved.
+        let ptr = unsafe { core::pin::Pin::new_unchecked(&*t) };
+
+        timer_init!(ptr, 0, "vgem_timer");
+
+        // SAFETY: Duration.as_millis() returns a valid total number of whole milliseconds.
+        let timeout =
+            unsafe { bindings::msecs_to_jiffies(Duration::from_secs(10).as_millis().try_into()?) };
+
+        // We force the fence to expire within 10s to prevent driver hangs
+        ptr.raw_timer().schedule_at(jiffies_later(timeout));
+
+        Ok(Self { fence, _timer: t })
     }
 }
 

--- a/drivers/gpu/drm/rustgem/file.rs
+++ b/drivers/gpu/drm/rustgem/file.rs
@@ -27,6 +27,14 @@ impl drm::file::DriverFile for File {
 }
 
 impl File {
+    pub(crate) fn dummy(
+        _device: &VgemDevice,
+        _data: &mut bindings::drm_vgem_dummy,
+        _file: &DrmFile,
+    ) -> Result<u32> {
+        Err(EINVAL)
+    }
+
     /// vgem_fence_attach_ioctl (DRM_IOCTL_VGEM_FENCE_ATTACH):
     ///
     /// Create and attach a fence to the vGEM handle. This fence is then exposed

--- a/drivers/gpu/drm/rustgem/file.rs
+++ b/drivers/gpu/drm/rustgem/file.rs
@@ -33,6 +33,10 @@ impl File {
     /// via the dma-buf reservation object and visible to consumers of the exported
     /// dma-buf.
     ///
+    /// This returns the handle for the new fence that must be signaled within 10
+    /// seconds (or otherwise it will automatically expire). See
+    /// signal (DRM_IOCTL_VGEM_FENCE_SIGNAL).
+    ///
     /// If the vGEM handle does not exist, attach returns -ENOENT.
     ///
     pub(crate) fn attach(
@@ -83,6 +87,9 @@ impl File {
     ///
     /// Signal and consume a fence earlier attached to a vGEM handle using
     /// attach (DRM_IOCTL_VGEM_FENCE_ATTACH).
+    ///
+    /// All fences must be signaled within 10s of attachment or otherwise they
+    /// will automatically expire (and signal returns -ETIMEDOUT).
     ///
     /// Signaling a fence indicates to all consumers of the dma-buf that the
     /// client has completed the operation associated with the fence, and that the

--- a/drivers/gpu/drm/rustgem/file.rs
+++ b/drivers/gpu/drm/rustgem/file.rs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+
+use crate::fence::VgemFence;
+use crate::gem::DriverObject;
+use crate::{VgemDevice, VgemDriver};
+use core::ops::Deref;
+use kernel::dma_fence::RawDmaFence;
+use kernel::drm::gem::BaseObject;
+use kernel::prelude::*;
+use kernel::{bindings, drm, drm::gem::shmem, xarray};
+
+pub(crate) struct File {
+    fences: xarray::XArray<Box<Option<VgemFence>>>,
+}
+
+/// Convenience type alias for our DRM `File` type.
+pub(crate) type DrmFile = drm::file::File<File>;
+
+impl drm::file::DriverFile for File {
+    type Driver = VgemDriver;
+
+    fn open(_device: &VgemDevice) -> Result<Box<Self>> {
+        Ok(Box::try_new(Self {
+            fences: xarray::XArray::new(xarray::flags::ALLOC1)?,
+        })?)
+    }
+}
+
+impl File {
+    /// vgem_fence_attach_ioctl (DRM_IOCTL_VGEM_FENCE_ATTACH):
+    ///
+    /// Create and attach a fence to the vGEM handle. This fence is then exposed
+    /// via the dma-buf reservation object and visible to consumers of the exported
+    /// dma-buf.
+    ///
+    /// If the vGEM handle does not exist, attach returns -ENOENT.
+    ///
+    pub(crate) fn attach(
+        _device: &VgemDevice,
+        data: &mut bindings::drm_vgem_fence_attach,
+        file: &DrmFile,
+    ) -> Result<u32> {
+        if (data.flags & !bindings::VGEM_FENCE_WRITE) != 0 {
+            return Err(EINVAL);
+        }
+
+        if data.pad != 0 {
+            return Err(EINVAL);
+        }
+
+        let obj = shmem::Object::<DriverObject>::lookup_handle(file, data.handle)?;
+
+        let fence = VgemFence::create()?;
+
+        // Check for a conflicting fence
+        let resv = obj.resv();
+        let usage = resv.usage_rw(data.flags & bindings::VGEM_FENCE_WRITE != 0);
+        if !resv.test_signaled(usage) {
+            fence.signal()?;
+            return Err(EBUSY);
+        }
+
+        let usage = if (data.flags & bindings::VGEM_FENCE_WRITE) != 0 {
+            bindings::dma_resv_usage_DMA_RESV_USAGE_WRITE
+        } else {
+            bindings::dma_resv_usage_DMA_RESV_USAGE_READ
+        };
+
+        // Expose the fence via the dma-buf
+        if resv.add_fences(fence.deref(), 1, usage).is_ok() {
+            // Record the fence in our xarray for later signaling
+            if let Ok(id) = file.fences.alloc(Some(Box::try_new(Some(fence))?)) {
+                data.out_fence = id as u32
+            }
+        } else {
+            fence.signal()?;
+        }
+
+        Ok(0)
+    }
+
+    /// vgem_fence_signal_ioctl (DRM_IOCTL_VGEM_FENCE_SIGNAL):
+    ///
+    /// Signal and consume a fence earlier attached to a vGEM handle using
+    /// attach (DRM_IOCTL_VGEM_FENCE_ATTACH).
+    ///
+    /// Signaling a fence indicates to all consumers of the dma-buf that the
+    /// client has completed the operation associated with the fence, and that the
+    /// buffer is then ready for consumption.
+    ///
+    /// If the fence does not exist (or has already been signaled by the client),
+    /// signal returns -ENOENT.
+    ///
+    pub(crate) fn signal(
+        _device: &VgemDevice,
+        data: &mut bindings::drm_vgem_fence_signal,
+        file: &DrmFile,
+    ) -> Result<u32> {
+        if data.flags != 0 {
+            return Err(EINVAL);
+        }
+
+        let fence = file
+            .fences
+            .replace(data.fence as usize, Box::try_new(None)?);
+
+        let fence = match fence {
+            Err(ret) => {
+                return Err(ret);
+            }
+            Ok(None) => {
+                return Err(ENOENT);
+            }
+            Ok(fence) => {
+                let fence = fence.unwrap().unwrap();
+
+                if fence.is_signaled() {
+                    return Err(ETIMEDOUT);
+                }
+
+                fence
+            }
+        };
+
+        fence.signal()?;
+        Ok(0)
+    }
+}

--- a/drivers/gpu/drm/rustgem/gem.rs
+++ b/drivers/gpu/drm/rustgem/gem.rs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+
+use kernel::{
+    drm::{gem, gem::shmem},
+    error::Result,
+};
+
+use crate::file::DrmFile;
+use crate::{VgemDevice, VgemDriver};
+
+/// Represents the inner data of a GEM object for this driver.
+pub(crate) struct DriverObject {}
+
+/// Type alias for the shmem GEM object type for this driver.
+pub(crate) type Object = shmem::Object<DriverObject>;
+
+impl gem::BaseDriverObject<Object> for DriverObject {
+    /// Callback to create the inner data of a GEM object
+    fn new(_dev: &VgemDevice, _size: usize) -> Result<Self> {
+        Ok(Self {})
+    }
+
+    /// Callback to drop all mappings for a GEM object owned by a given `File`
+    fn close(_obj: &Object, _file: &DrmFile) {}
+}
+
+impl shmem::DriverObject for DriverObject {
+    type Driver = VgemDriver;
+
+    const MAP_WC: bool = true;
+}

--- a/drivers/gpu/drm/rustgem/vgem.rs
+++ b/drivers/gpu/drm/rustgem/vgem.rs
@@ -55,6 +55,7 @@ impl drv::Driver for VgemDriver {
     const FEATURES: u32 = drv::FEAT_GEM | drv::FEAT_RENDER;
 
     kernel::declare_drm_ioctls! {
+        (VGEM_DUMMY, drm_vgem_dummy, ioctl::RENDER_ALLOW, file::File::dummy),
         (VGEM_FENCE_ATTACH, drm_vgem_fence_attach, ioctl::RENDER_ALLOW, file::File::attach),
         (VGEM_FENCE_SIGNAL, drm_vgem_fence_signal, ioctl::RENDER_ALLOW, file::File::signal),
     }

--- a/drivers/gpu/drm/rustgem/vgem.rs
+++ b/drivers/gpu/drm/rustgem/vgem.rs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+
+//! Driver for a Virtual GEM service.
+
+use kernel::driver::DeviceRemoval;
+use kernel::macros::vtable;
+use kernel::{
+    c_str, device, drm,
+    drm::{drv, ioctl},
+    error::Result,
+    platform,
+    prelude::*,
+    sync::Arc,
+};
+
+mod fence;
+mod file;
+mod gem;
+
+/// Driver metadata
+const INFO: drv::DriverInfo = drv::DriverInfo {
+    major: 1,
+    minor: 0,
+    patchlevel: 0,
+    name: c_str!("vgem"),
+    desc: c_str!("Virtual GEM provider"),
+    date: c_str!("20230201"),
+};
+
+struct Vgem {
+    data: Arc<DeviceData>,
+    _resource: device::Resource,
+    _pdev: platform::Device,
+}
+
+/// Empty struct representing this driver.
+pub(crate) struct VgemDriver;
+
+/// Convenience type alias for the DRM device type for this driver.
+pub(crate) type VgemDevice = kernel::drm::device::Device<VgemDriver>;
+
+///// Convenience type alias for the `device::Data` type for this driver.
+type DeviceData = device::Data<drv::Registration<VgemDriver>, (), ()>;
+
+#[vtable]
+impl drv::Driver for VgemDriver {
+    /// Our `DeviceData` type, reference-counted
+    type Data = Arc<DeviceData>;
+    /// Our `File` type.
+    type File = file::File;
+    /// Our `Object` type.
+    type Object = gem::Object;
+
+    const INFO: drv::DriverInfo = INFO;
+    const FEATURES: u32 = drv::FEAT_GEM | drv::FEAT_RENDER;
+
+    kernel::declare_drm_ioctls! {
+        (VGEM_FENCE_ATTACH, drm_vgem_fence_attach, ioctl::RENDER_ALLOW, file::File::attach),
+        (VGEM_FENCE_SIGNAL, drm_vgem_fence_signal, ioctl::RENDER_ALLOW, file::File::signal),
+    }
+}
+
+impl kernel::Module for Vgem {
+    fn init(_name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
+        let mut pdev = platform::Device::register(c_str!("vgem"), -1)?;
+        let dev = device::Device::from_dev(&pdev);
+
+        let resource = dev.open_group(core::ptr::null_mut() as *mut core::ffi::c_void)?;
+
+        pdev.coerse_dma_masks(u64::MAX)?;
+
+        let reg = drm::drv::Registration::<VgemDriver>::new(&dev)?;
+
+        let data = kernel::new_device_data!(reg, (), (), "Vgem::Registrations")?;
+
+        let data = Arc::<DeviceData>::from(data);
+
+        kernel::drm_device_register!(
+            data.registrations().ok_or(ENXIO)?.as_pinned_mut(),
+            data.clone(),
+            0
+        )?;
+
+        Ok(Vgem {
+            _pdev: pdev,
+            _resource: resource,
+            data,
+        })
+    }
+}
+
+impl Drop for Vgem {
+    fn drop(&mut self) {
+        self.data.device_remove();
+    }
+}
+
+module! {
+    type: Vgem,
+    name: "vgem",
+    author: "Maíra Canal",
+    description: "Virtual GEM provider",
+    license: "GPL",
+}

--- a/include/uapi/drm/vgem_drm.h
+++ b/include/uapi/drm/vgem_drm.h
@@ -36,8 +36,11 @@ extern "C" {
 /* Please note that modifications to all structs defined here are
  * subject to backwards-compatibility constraints.
  */
+#define DRM_VGEM_DUMMY		0x0
 #define DRM_VGEM_FENCE_ATTACH	0x1
 #define DRM_VGEM_FENCE_SIGNAL	0x2
+
+struct drm_vgem_dummy { };
 
 struct drm_vgem_fence_attach {
 	__u32 handle;
@@ -54,6 +57,7 @@ struct drm_vgem_fence_signal {
 
 /* Note: this is an enum so that it can be resolved by Rust bindgen. */
 enum {
+	DRM_IOCTL_VGEM_DUMMY		= DRM_IOW(DRM_COMMAND_BASE + DRM_VGEM_DUMMY, struct drm_vgem_dummy),
 	DRM_IOCTL_VGEM_FENCE_ATTACH	= DRM_IOWR(DRM_COMMAND_BASE + DRM_VGEM_FENCE_ATTACH, struct drm_vgem_fence_attach),
 	DRM_IOCTL_VGEM_FENCE_SIGNAL	= DRM_IOW(DRM_COMMAND_BASE + DRM_VGEM_FENCE_SIGNAL, struct drm_vgem_fence_signal),
 };

--- a/include/uapi/drm/vgem_drm.h
+++ b/include/uapi/drm/vgem_drm.h
@@ -39,9 +39,6 @@ extern "C" {
 #define DRM_VGEM_FENCE_ATTACH	0x1
 #define DRM_VGEM_FENCE_SIGNAL	0x2
 
-#define DRM_IOCTL_VGEM_FENCE_ATTACH	DRM_IOWR( DRM_COMMAND_BASE + DRM_VGEM_FENCE_ATTACH, struct drm_vgem_fence_attach)
-#define DRM_IOCTL_VGEM_FENCE_SIGNAL	DRM_IOW( DRM_COMMAND_BASE + DRM_VGEM_FENCE_SIGNAL, struct drm_vgem_fence_signal)
-
 struct drm_vgem_fence_attach {
 	__u32 handle;
 	__u32 flags;
@@ -53,6 +50,12 @@ struct drm_vgem_fence_attach {
 struct drm_vgem_fence_signal {
 	__u32 fence;
 	__u32 flags;
+};
+
+/* Note: this is an enum so that it can be resolved by Rust bindgen. */
+enum {
+	DRM_IOCTL_VGEM_FENCE_ATTACH	= DRM_IOWR(DRM_COMMAND_BASE + DRM_VGEM_FENCE_ATTACH, struct drm_vgem_fence_attach),
+	DRM_IOCTL_VGEM_FENCE_SIGNAL	= DRM_IOW(DRM_COMMAND_BASE + DRM_VGEM_FENCE_SIGNAL, struct drm_vgem_fence_signal),
 };
 
 #if defined(__cplusplus)

--- a/rust/bindings/bindings_helper.h
+++ b/rust/bindings/bindings_helper.h
@@ -19,6 +19,7 @@
 #include <linux/dma-fence.h>
 #include <linux/dma-fence-chain.h>
 #include <linux/dma-mapping.h>
+#include <linux/dma-resv.h>
 #include <linux/fs.h>
 #include <linux/iosys-map.h>
 #include <linux/io-pgtable.h>

--- a/rust/bindings/bindings_helper.h
+++ b/rust/bindings/bindings_helper.h
@@ -37,6 +37,7 @@
 #include <linux/xarray.h>
 #include <uapi/asm-generic/ioctl.h>
 #include <uapi/drm/drm.h>
+#include <uapi/drm/vgem_drm.h>
 
 /* `bindgen` gets confused at certain things. */
 const gfp_t BINDINGS_GFP_KERNEL = GFP_KERNEL;

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -344,6 +344,12 @@ bool rust_helper_of_node_is_root(const struct device_node *np)
 }
 EXPORT_SYMBOL_GPL(rust_helper_of_node_is_root);
 
+int rust_helper_dma_coerce_mask_and_coherent(struct device *dev, u64 mask)
+{
+	return dma_coerce_mask_and_coherent(dev, mask);
+}
+EXPORT_SYMBOL_GPL(rust_helper_dma_coerce_mask_and_coherent);
+
 struct device_node *rust_helper_of_parse_phandle(const struct device_node *np,
 		const char *phandle_name,
 		int index)

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -420,6 +420,12 @@ void rust_helper_dma_fence_put(struct dma_fence *fence)
 }
 EXPORT_SYMBOL_GPL(rust_helper_dma_fence_put);
 
+bool rust_helper_dma_fence_is_signaled(struct dma_fence *fence)
+{
+	return dma_fence_is_signaled(fence);
+}
+EXPORT_SYMBOL_GPL(rust_helper_dma_fence_is_signaled);
+
 struct dma_fence_chain *rust_helper_dma_fence_chain_alloc(void)
 {
 	return dma_fence_chain_alloc();

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -25,6 +25,7 @@
 #include <linux/build_bug.h>
 #include <linux/device.h>
 #include <linux/dma-fence.h>
+#include <linux/dma-resv.h>
 #include <linux/dma-fence-chain.h>
 #include <linux/dma-mapping.h>
 #include <linux/err.h>
@@ -436,6 +437,24 @@ void rust_helper_dma_fence_set_error(struct dma_fence *fence, int error)
 	dma_fence_set_error(fence, error);
 }
 EXPORT_SYMBOL_GPL(rust_helper_dma_fence_set_error);
+
+enum dma_resv_usage rust_helper_dma_resv_usage_rw(bool write)
+{
+	return dma_resv_usage_rw(write);
+}
+EXPORT_SYMBOL_GPL(rust_helper_dma_resv_usage_rw);
+
+int rust_helper_dma_resv_lock(struct dma_resv *obj, struct ww_acquire_ctx *ctx)
+{
+	return dma_resv_lock(obj, ctx);
+}
+EXPORT_SYMBOL_GPL(rust_helper_dma_resv_lock);
+
+void rust_helper_dma_resv_unlock(struct dma_resv *obj)
+{
+	dma_resv_unlock(obj);
+}
+EXPORT_SYMBOL_GPL(rust_helper_dma_resv_unlock);
 
 #endif
 

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -323,6 +323,14 @@ rust_helper_platform_set_drvdata(struct platform_device *pdev,
 }
 EXPORT_SYMBOL_GPL(rust_helper_platform_set_drvdata);
 
+struct platform_device *
+rust_helper_platform_device_register_simple(const char *name, int id,
+					    const struct resource *res, unsigned int num)
+{
+	return platform_device_register_simple(name, id, res, num);
+}
+EXPORT_SYMBOL_GPL(rust_helper_platform_device_register_simple);
+
 const struct of_device_id *rust_helper_of_match_device(
 		const struct of_device_id *matches, const struct device *dev)
 {

--- a/rust/kernel/device.rs
+++ b/rust/kernel/device.rs
@@ -8,6 +8,7 @@ use crate::{
     bindings,
     error::Result,
     of,
+    prelude::ENOMEM,
     revocable::{Revocable, RevocableGuard},
     str::CStr,
     sync::{LockClassKey, NeedsLockClass, RevocableMutex, RevocableMutexGuard, UniqueArc},
@@ -199,6 +200,25 @@ impl Device {
         // requirements.
         unsafe { Self::new(dev.raw_device()) }
     }
+
+    /// Open a new devres group for dev with id.
+    pub fn open_group(&self, id: *mut core::ffi::c_void) -> Result<Resource> {
+        // SAFETY: The requirements are satisfied by the existence of `RawDevice` and its safety
+        // requirements.
+        let id = unsafe {
+            // Keep the allocation flags as GFP_KERNEL, as currently all users
+            // are using this flag.
+            bindings::devres_open_group(self.raw_device(), id, bindings::GFP_KERNEL)
+        };
+
+        if id.is_null() {
+            return Err(ENOMEM);
+        }
+        Ok(Resource {
+            dev: self.raw_device(),
+            id,
+        })
+    }
 }
 
 // SAFETY: The device returned by `raw_device` is the one for which we hold a reference.
@@ -221,6 +241,26 @@ impl Clone for Device {
         Device::from_dev(self)
     }
 }
+
+/// Device Resource Management
+pub struct Resource {
+    dev: *mut bindings::device,
+    id: *mut core::ffi::c_void,
+}
+
+impl Drop for Resource {
+    /// Release resources in a devres group
+    fn drop(&mut self) {
+        // SAFETY: The resource was properly allocated by the Device
+        unsafe { bindings::devres_release_group(self.dev, self.id) };
+    }
+}
+
+// SAFETY: The API doesn't allow access to the internal pointers.
+unsafe impl Send for Resource {}
+
+// SAFETY: The API doesn't allow access to the internal pointers.
+unsafe impl Sync for Resource {}
 
 /// Device data.
 ///

--- a/rust/kernel/dma_fence.rs
+++ b/rust/kernel/dma_fence.rs
@@ -60,6 +60,13 @@ pub trait RawDmaFence: crate::private::Sealed {
         }
     }
 
+    /// Return the seqno from this fence
+    fn seqno(&self) -> u64 {
+        // SAFETY: We hold a reference to a dma_fence and every dma_fence holds
+        // a seqno.
+        unsafe { (*self.raw()).seqno }
+    }
+
     /// Signal completion of this fence
     fn signal(&self) -> Result {
         to_result(unsafe { bindings::dma_fence_signal(self.raw()) })

--- a/rust/kernel/dma_fence.rs
+++ b/rust/kernel/dma_fence.rs
@@ -65,6 +65,11 @@ pub trait RawDmaFence: crate::private::Sealed {
         to_result(unsafe { bindings::dma_fence_signal(self.raw()) })
     }
 
+    /// Return an indication if the fence is signaled yet.
+    fn is_signaled(&self) -> bool {
+        unsafe { bindings::dma_fence_is_signaled(self.raw()) }
+    }
+
     /// Set the error flag on this fence
     fn set_error(&self, err: Error) {
         unsafe { bindings::dma_fence_set_error(self.raw(), err.to_kernel_errno()) };

--- a/rust/kernel/dma_resv.rs
+++ b/rust/kernel/dma_resv.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0 OR MIT
+
+//! DMA resv abstraction
+//!
+//! C header: [`include/linux/dma-resv.h`](../../include/linux/dma-resv.h)
+
+use crate::bindings;
+use crate::dma_fence::RawDmaFence;
+use crate::error::{Error, Result};
+
+/// A generic DMA Resv Object
+///
+/// # Invariants
+/// ptr is a valid pointer to a dma_resv and we own a reference to it.
+pub struct DmaResv {
+    ptr: *mut bindings::dma_resv,
+}
+
+impl DmaResv {
+    /// Create a new DmaResv object from a raw pointer to a dma_resv.
+    ///
+    /// # Safety
+    /// The caller must own a reference to the dma_resv, which is transferred to the new object.
+    pub unsafe fn from_raw(ptr: *mut bindings::dma_resv) -> Self {
+        Self { ptr }
+    }
+
+    /// Returns the implicit synchronization usage for write or read accesses.
+    pub fn usage_rw(&self, write: bool) -> bindings::dma_resv_usage {
+        // SAFETY: write is a valid bool.
+        unsafe { bindings::dma_resv_usage_rw(write) }
+    }
+
+    /// Reserve space to add fences to a dma_resv object.
+    pub fn reserve_fences(&self, num_fences: u32) -> Result {
+        // SAFETY: We own a reference to this dma_resv.
+        let ret = unsafe { bindings::dma_resv_reserve_fences(self.ptr, num_fences) };
+
+        if ret != 0 {
+            return Err(Error::from_kernel_errno(ret));
+        }
+        Ok(())
+    }
+
+    /// Add a fence to the dma_resv object
+    pub fn add_fences(
+        &self,
+        fence: &dyn RawDmaFence,
+        num_fences: u32,
+        usage: bindings::dma_resv_usage,
+    ) -> Result {
+        // SAFETY: We own a reference to this dma_resv.
+        unsafe { bindings::dma_resv_lock(self.ptr, core::ptr::null_mut()) };
+
+        let ret = self.reserve_fences(num_fences);
+        if ret.is_ok() {
+            // SAFETY: ptr is locked with dma_resv_lock(), and dma_resv_reserve_fences()
+            // has been called.
+            unsafe {
+                bindings::dma_resv_add_fence(self.ptr, fence.raw(), usage);
+            }
+        }
+
+        // SAFETY: We own a reference to this dma_resv.
+        unsafe { bindings::dma_resv_unlock(self.ptr) };
+
+        ret
+    }
+
+    /// Test if a reservation object’s fences have been signaled.
+    pub fn test_signaled(&self, usage: bindings::dma_resv_usage) -> bool {
+        // SAFETY: We own a reference to this dma_resv.
+        unsafe { bindings::dma_resv_test_signaled(self.ptr, usage) }
+    }
+}

--- a/rust/kernel/drm/gem/mod.rs
+++ b/rust/kernel/drm/gem/mod.rs
@@ -11,6 +11,7 @@ use alloc::boxed::Box;
 
 use crate::{
     bindings,
+    dma_resv::DmaResv,
     drm::{device, drv, file},
     error::{to_result, Result},
     prelude::*,
@@ -134,6 +135,12 @@ pub trait BaseObject: IntoGEMObject {
     /// Returns the size of the object in bytes.
     fn size(&self) -> usize {
         self.gem_obj().size
+    }
+
+    /// Returns the pointer to reservation object associated with this GEM object.
+    fn resv(&self) -> DmaResv {
+        // SAFETY: Every GEM object holds a reference to a reservation object
+        unsafe { DmaResv::from_raw(self.gem_obj().resv) }
     }
 
     /// Sets the exportable flag, which controls whether the object can be exported via PRIME.

--- a/rust/kernel/drm/gem/shmem.rs
+++ b/rust/kernel/drm/gem/shmem.rs
@@ -24,6 +24,9 @@ use gem::BaseObject;
 pub trait DriverObject: gem::BaseDriverObject<Object<Self>> {
     /// Parent `Driver` for this object.
     type Driver: drv::Driver;
+
+    /// Define the map object write-combined
+    const MAP_WC: bool = false;
 }
 
 // FIXME: This is terrible and I don't know how to avoid it
@@ -110,6 +113,8 @@ unsafe extern "C" fn gem_create_object<T: DriverObject>(
     let new: &mut Object<T> = unsafe { &mut *(p as *mut _) };
 
     new.obj.base.funcs = &Object::<T>::VTABLE;
+    new.obj.map_wc = <T>::MAP_WC;
+
     &mut new.obj.base
 }
 

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -225,3 +225,15 @@ macro_rules! container_of {
         ptr.wrapping_offset(-offset) as *const $type
     }}
 }
+
+/// Initializes a timer.
+///
+/// It automatically defines a new lockdep lock for the timer.
+#[macro_export]
+macro_rules! timer_init {
+    ($timer:expr, $flags:expr, $name:expr) => {{
+        static CLASS: $crate::sync::LockClassKey = $crate::sync::LockClassKey::new();
+
+        $timer.init_timer($flags, $crate::c_str!($name), &CLASS);
+    }};
+}

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -38,6 +38,7 @@ pub mod delay;
 pub mod device;
 #[cfg(CONFIG_DMA_SHARED_BUFFER)]
 pub mod dma_fence;
+pub mod dma_resv;
 pub mod driver;
 #[cfg(CONFIG_DRM = "y")]
 pub mod drm;

--- a/rust/kernel/platform.rs
+++ b/rust/kernel/platform.rs
@@ -216,6 +216,12 @@ impl Device {
         to_result(unsafe { bindings::dma_set_mask_and_coherent(&mut (*self.ptr).dev, mask) })
     }
 
+    /// Similar to the above, except it deals with the case where the device
+    /// does not have dev->dma_mask appropriately setup.
+    pub fn coerse_dma_masks(&mut self, mask: u64) -> Result {
+        to_result(unsafe { bindings::dma_coerce_mask_and_coherent(&mut (*self.ptr).dev, mask) })
+    }
+
     /// Gets a system resources of a platform device.
     pub fn get_resource(&mut self, rtype: IoResource, num: usize) -> Result<Resource> {
         // SAFETY: `self.ptr` is valid by the type invariant.

--- a/rust/kernel/platform.rs
+++ b/rust/kernel/platform.rs
@@ -167,6 +167,13 @@ pub struct Device {
     used_resource: u64,
 }
 
+// SAFETY: `Device` only holds a pointer to a C device, which is safe to be used from any thread.
+unsafe impl Send for Device {}
+
+// SAFETY: `Device` only holds a pointer to a C device, references to which are safe to be used
+// from any thread.
+unsafe impl Sync for Device {}
+
 impl Device {
     /// Creates a new device from the given pointer.
     ///

--- a/rust/kernel/time.rs
+++ b/rust/kernel/time.rs
@@ -1,23 +1,51 @@
-// SPDX-License-Identifier: GPL-2.0
-
-//! Timekeeping functions.
+//! Time and Timers
 //!
-//! C header: [`include/linux/ktime.h`](../../../../include/linux/ktime.h)
-//! C header: [`include/linux/timekeeping.h`](../../../../include/linux/timekeeping.h)
+//! This module allows Rust code to operate jiffy-based timestamps and timers.
+//!
+//! C header: [`include/linux/jiffies.h`](../../../../include/linux/jiffies.h)
+use core::sync::atomic::{compiler_fence, AtomicUsize, Ordering};
 
-use crate::bindings;
-use core::time::Duration;
+pub mod timer;
 
-/// Returns the kernel time elapsed since boot, excluding time spent sleeping, as a [`Duration`].
-pub fn ktime_get() -> Duration {
-    Duration::from_nanos(unsafe { bindings::ktime_get() }.try_into().unwrap())
+/// The time unit of Linux kernel. One jiffy equals (1/HZ) second.
+pub type Jiffies = core::ffi::c_ulong;
+
+/// Gets the current jiffies counter.
+pub fn jiffies_now() -> Jiffies {
+    extern "C" {
+        static jiffies: core::cell::UnsafeCell<Jiffies>;
+    }
+
+    compiler_fence(Ordering::SeqCst); // Enforces volatile.
+
+    // SAFETY: For linux targets,`core::ffi::c_ulong` == `usize`, therefore it's safe to covert
+    // the address of `jiffies` into a `*const AtomicUsize`.
+    //
+    // The atomic load is needed here because Linux kernel memory model assumes volatile reads and
+    // writes on natural aligned words are atomic, while `read_volatile` of Rust doesn't provide
+    // the same guarantee, so convert to atomic load to avoid data race. Besides since Rust atomic
+    // is not volatile, compiler barriers are used to enforce the volatile semantics of load on
+    // `jiffies`.
+    let j = unsafe { &*(jiffies.get() as *const AtomicUsize) }.load(Ordering::Relaxed) as Jiffies;
+
+    compiler_fence(Ordering::SeqCst); // Enforces volatile.
+
+    j
 }
 
-/// Returns the kernel time elapsed since boot, including time spent sleeping, as a [`Duration`].
-pub fn ktime_get_boottime() -> Duration {
-    Duration::from_nanos(
-        unsafe { bindings::ktime_get_with_offset(bindings::tk_offsets_TK_OFFS_BOOT) }
-            .try_into()
-            .unwrap(),
-    )
+/// Gets the current + `duration` jiffies.
+pub fn jiffies_later(duration: Jiffies) -> Jiffies {
+    jiffies_now().wrapping_add(duration)
+}
+
+/// Checks whether `t1` is before or equals to `t2`.
+///
+/// See `time_before_eq()` in the Linux header file.
+pub fn before_or_equal(t1: Jiffies, t2: Jiffies) -> bool {
+    t2.wrapping_sub(t1) as core::ffi::c_long >= 0
+}
+
+/// Checks whether `expires` has been expired.
+pub fn jiffies_expired(expires: Jiffies) -> bool {
+    before_or_equal(expires, jiffies_now())
 }

--- a/rust/kernel/time/timer.rs
+++ b/rust/kernel/time/timer.rs
@@ -1,0 +1,228 @@
+//! Timers
+//!
+//! This module allows Rust code to use the coarse-gained kernel timers (jiffies based).
+//!
+//! C header: [`include/linux/timer.h`](../../../../include/linux/timer.h)
+
+use core::{marker::PhantomPinned, pin::Pin};
+
+use crate::container_of;
+use crate::{bindings::timer_list, prelude::*, str::CStr, sync::LockClassKey, types::Opaque};
+
+use super::*;
+
+/// A raw timer.
+#[repr(transparent)]
+pub struct RawTimer {
+    opaque: Opaque<timer_list>,
+
+    /// [`RawTimer`] is `!Unpin`, since [`timer_list`] contains self-referential pointers.
+    _p: PhantomPinned,
+}
+
+/// Timeout trait.
+///
+/// # Safety
+///
+/// This trait is unsafe because this trait implies there is a [`RawTimer`] inside the struct,
+/// and if it's armed, it may be called at any time and may access the struct. Therefore the `drop`
+/// function of an `impl Timeout` needs to make sure the [`RawTimer`] is shutdown before freeing
+/// other members, otherwise it's UAF.
+pub unsafe trait Timeout: Sized {
+    /// Called with time is up.
+    ///
+    /// # Safety
+    ///
+    /// This can only be called inside [`RawTimer::bridge`], otherwise there may be a data race.
+    ///
+    /// # Implementation
+    ///
+    /// * `timeout` can only access the outer type.
+    /// * `timeout` cannot operate on the [`RawTimer`].
+    /// * `timeout` should be locally safe.
+    unsafe fn timeout(_: *mut RawTimer) -> Result<Next>;
+
+    /// Gets the pinned reference to the inner [`RawTimer`].
+    fn raw_timer(self: Pin<&Self>) -> Pin<&RawTimer>;
+
+    /// Initialises the [`RawTimer`] inside.
+    ///
+    /// XXX: this probably goes way with pin-init.
+    fn init_timer(self: Pin<&Self>, flags: u32, name: &'static CStr, key: &'static LockClassKey) {
+        self.raw_timer().init::<Self>(flags, name, key);
+    }
+}
+
+impl RawTimer {
+    /// Creates a [`RawTimer`].
+    ///
+    /// # Safety
+    ///
+    /// The caller must call [`RawTimer::init`] before using the timer.
+    pub unsafe fn new() -> Self {
+        RawTimer {
+            opaque: Opaque::uninit(),
+            _p: PhantomPinned,
+        }
+    }
+
+    extern "C" fn bridge<T: Timeout>(ptr: *mut bindings::timer_list) {
+        let ptr = ptr.cast::<RawTimer>();
+
+        // SAFETY: Inside [`Timer::bridge`], it's safe.
+        let next = unsafe { T::timeout(ptr) };
+
+        // SAFTEFY: See the `expire_timers` function at C side, `ptr` points to this very same
+        // [`RawTimer`] object (transparent to a `timer_list`), therefore `ptr` is valid.
+        let timer = unsafe { &*ptr };
+
+        match next {
+            Ok(Next::Again(duration)) => {
+                timer.schedule_at(jiffies_later(duration));
+            }
+            Err(_err) => {
+                todo!("need Error::name()");
+            }
+            _ => {}
+        }
+    }
+
+    /// Initialises a [`RawTimer`].
+    fn init<T: Timeout>(
+        self: Pin<&Self>,
+        flags: u32,
+        name: &'static CStr,
+        key: &'static LockClassKey,
+    ) {
+        // SAFTEFY: `self.opaque.get()` is a valid pointer to a [`timer_list`], and
+        // `Self::bridge::<T>` is a safe function.
+        unsafe {
+            bindings::init_timer_key(
+                self.opaque.get(),
+                Some(Self::bridge::<T>),
+                flags,
+                name.as_char_ptr(),
+                key.get(),
+            );
+        }
+    }
+
+    /// Schedules a timer.
+    ///
+    /// Interior mutability is provided by `mod_timer()`. It's safe to call even inside a timer
+    /// callback.
+    pub fn schedule_at(&self, expires: Jiffies) {
+        // SAFETY: `self.opaque.get()` is a valid pointer to a [`timer_list`] and it's already
+        // initialized per the safe guarantee of [`RawTimer::new`].
+        unsafe {
+            bindings::mod_timer(self.opaque.get(), expires);
+        }
+    }
+
+    /// Cancels a scheduled timer.
+    ///
+    /// Callers should guarantee that the timer will eventually stop re-schedule itself, otherwise
+    /// it's not guaranteed that this function will return.
+    ///
+    /// This function will wait until the timer callback finishes. Return `true` is the timer was
+    /// pending and got deactivated.
+    pub fn cancel(&self) -> bool {
+        // SAFETY: `self.opaque.get()` is a valid pointer to a [`timer_list`] and it's already
+        // initialized per the safe guarantee of `init`.
+        (unsafe { bindings::timer_delete_sync(self.opaque.get()) }) != 0
+    }
+
+    /// Shutdowns a scheduled timer.
+    ///
+    /// This function will wait until the timer callback finishes, and also make any future
+    /// schedule of the timer no-ops.
+    pub fn shutdown(&self) {
+        // SAFETY: `self.opaque.get()` is a valid pointer to a [`timer_list`] and it's already
+        // initialized per the safe guarantee of `init`.
+        unsafe {
+            bindings::timer_shutdown_sync(self.opaque.get());
+        }
+    }
+}
+
+impl Drop for RawTimer {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+// SAFETY: A `timer_list` can be transferred between threads.
+unsafe impl Send for RawTimer {}
+
+/// Next action of the timer.
+pub enum Next {
+    /// No more next step.
+    Done,
+    /// Schedules a timer to trigger later.
+    Again(Jiffies),
+}
+
+/// A simple closure timer.
+pub struct FnTimer<F>
+where
+    F: Sync, // SYNC: `F` may be called on other CPU.
+    F: FnMut() -> Result<Next>,
+{
+    raw: RawTimer,
+    f: F,
+}
+
+impl<F> FnTimer<F>
+where
+    F: Sync,
+    F: FnMut() -> Result<Next>,
+{
+    /// Creates a [`FnTimer`].
+    ///
+    /// # Safety
+    ///
+    /// The caller must call [`FnTimer::init_timer`] before using the timer.
+    pub unsafe fn new(f: F) -> Self {
+        Self {
+            // SAFTEFY: Guaranteed by safety requirement of [`FnTimer::new`].
+            raw: unsafe { RawTimer::new() },
+            f,
+        }
+    }
+}
+
+// SAFETY: [`FnTimer::drop`] shutdown the [`RawTimer`] first.
+unsafe impl<F> Timeout for FnTimer<F>
+where
+    F: Sync,
+    F: FnMut() -> Result<Next>,
+{
+    fn raw_timer(self: Pin<&Self>) -> Pin<&RawTimer> {
+        // SAFETY: `self` is pinned, therefore its field should always be pinned.
+        unsafe { self.map_unchecked(|f| &f.raw) }
+    }
+
+    unsafe fn timeout(ptr: *mut RawTimer) -> Result<Next> {
+        let obj = container_of!(ptr, Self, raw) as *mut Self;
+
+        // IPML & SAFETY: Per safety guarantee of `timeout`, it's only called inside a timer bridge
+        // function, and `ptr` is a pointer to [`Self::raw`], therefore `obj` is a vaild pointer
+        // to [`Self`]. [`FnTimer`] is pinned before `init_timer`, so no risk of being moved. No
+        // other way to access [`FnTimer::f`], so no data race. And [`FnTimer::drop`] needs to wait
+        // for the ongoing timer to finish, so no UAF. Hence it safe to dereference as mut here.
+        unsafe { ((*obj).f)() }
+    }
+}
+
+impl<F> Drop for FnTimer<F>
+where
+    F: Sync,
+    F: FnMut() -> Result<Next>,
+{
+    fn drop(&mut self) {
+        // SAFETY: `self` is going to drop, no one will move `self`.
+        let pin = unsafe { Pin::new_unchecked(&*self) };
+
+        pin.raw_timer().shutdown();
+    }
+}


### PR DESCRIPTION
# TODO

- [x] Make the DRM device be unregistered upon removal
- [x] Add timeout feature
- [x] Are all fences being properly put?
- [x] Implement the close callback: It is unnecessary as Xarray deals with the drop for us
- [x] Is the timer being properly deallocated?
- [x] Inspect all possible error cases
- [x] Add all the SAFETY comments
- [x] Fix all the FIXME commits
- [x] Use Boqun's Timer Abstraction

# Questions

- [x] Is a mutex needed to protect Xarray? No!
     - rust/kernel/xarray.rs:293: // SAFETY: XArray is thread-safe and all mutation operations are internally locked.

- [ ] It works with seqno = 0 for some reason

# Possible Improvements

- [x] Xarray can hold a VgemFence instead of a UniqueFence<VgemFence>

# RFC

- v1: https://lore.kernel.org/dri-devel/20230317121213.93991-1-mcanal@igalia.com/T/